### PR TITLE
feat: read query param delay as time.Duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,10 @@ The server exposes a single endpoint:
 `GET /`
 
 Optional query params:
-- `delay` (integer): minimum duration in milliseconds before response
-- `fib` (integer): nth element in fibonacci's suite to calculate before reponse
+- `delay` (`time.Duration`): minimum duration before response
+- `fib` (`int`): nth element in fibonacci's suite to calculate before reponse
+
+Examples:
+- `http://localhost:9999?delay=250ms`
+- `http://localhost:9999?fib=40`
+- `http://localhost:9999?fib=40&delay=3s`

--- a/handle.go
+++ b/handle.go
@@ -18,7 +18,7 @@ const (
 func handle(w http.ResponseWriter, r *http.Request) {
 	params := r.URL.Query()
 
-	delayMS, err := readParamInt(params, paramkeyDelay)
+	delay, err := readParamDuration(params, paramkeyDelay)
 	if err != nil {
 		respondError(w, 400, err)
 		return
@@ -30,8 +30,8 @@ func handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if delayMS > 0 {
-		time.Sleep(time.Duration(delayMS) * time.Millisecond)
+	if delay > 0 {
+		time.Sleep(delay)
 	}
 
 	if fibInt > 0 {
@@ -51,6 +51,20 @@ func readParamInt(params url.Values, key paramkey) (int, error) {
 	}
 
 	return n, nil
+}
+
+func readParamDuration(params url.Values, key paramkey) (time.Duration, error) {
+	raw := params.Get(string(key))
+	if raw == "" {
+		return 0, nil
+	}
+
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("invalid param: %s: want parsable duration, got %s", key, raw)
+	}
+
+	return d, nil
 }
 
 func respondError(w http.ResponseWriter, code int, err error) {

--- a/handle_test.go
+++ b/handle_test.go
@@ -12,10 +12,14 @@ import (
 
 func TestHandle(t *testing.T) {
 	t.Run("request with delay param", func(t *testing.T) {
-		const delay = 100
-		const expmin, expmax = delay * time.Millisecond, (delay + 10) * time.Millisecond
+		const (
+			delay  = 100 * time.Millisecond
+			margin = 5 * time.Millisecond
+			expmin = delay
+			expmax = delay + margin
+		)
 
-		r := httptest.NewRequest("", fmt.Sprintf("/?delay=%d", delay), nil)
+		r := httptest.NewRequest("", fmt.Sprintf("/?delay=%dms", delay.Milliseconds()), nil)
 
 		testx.HTTPHandlerFunc(handle).WithRequest(r).
 			Response(checkStatusCode(200)).
@@ -24,8 +28,11 @@ func TestHandle(t *testing.T) {
 	})
 
 	t.Run("request with fib param", func(t *testing.T) {
-		const fib = 35
-		const expmin, expmax = 30 * time.Millisecond, 60 * time.Millisecond
+		const (
+			fib    = 35
+			expmin = 30 * time.Millisecond
+			expmax = 80 * time.Millisecond
+		)
 
 		r := httptest.NewRequest("", fmt.Sprintf("/?fib=%d", fib), nil)
 


### PR DESCRIPTION
<!-- IMPORTANT: Don't forget to link the issue(s) once the PR created! -->

## Description

Read query param `delay` as a parsable `time.Duration` instead of implicit raw `ìnt` milliseconds.

<!--
    Describe briefly what this PR does, if the issue description is not enough.
    Add any information that could be relevant for the reviewers.
-->

## Changes

<!-- Optional: mention here indirect changes impacted by the PR -->

## Notes

<!-- Optional: additional notes than can help understanding the implementation -->
