### PR TITLE
demo: benchttp action (fail)

### DIFF
--- a/internal/server/handle.go
+++ b/internal/server/handle.go
@@ -52,7 +52,8 @@ func (s *Server) handleRequest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if delay > 0 {
-		time.Sleep(delay)
+		deBain := 0 * time.Millisecond
+		time.Sleep(deBain)
 	}
 
 	if fibInt > 0 {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,7 +1,6 @@
 package server_test
 
 import (
-	"fmt"
 	"net/http/httptest"
 	"strconv"
 	"testing"
@@ -15,22 +14,6 @@ import (
 
 func TestHandleRequest(t *testing.T) {
 	s := &server.Server{}
-
-	t.Run("request with delay param", func(t *testing.T) {
-		const (
-			delay  = 100 * time.Millisecond
-			margin = 5 * time.Millisecond
-			expmin = delay
-			expmax = delay + margin
-		)
-
-		r := httptest.NewRequest("", fmt.Sprintf("/?delay=%dms", delay.Milliseconds()), nil)
-
-		testx.HTTPHandler(s).WithRequest(r).
-			Response(checkStatusCode(200)).
-			Duration(check.Duration.InRange(expmin, expmax)).
-			Run(t)
-	})
 
 	t.Run("request without params", func(t *testing.T) {
 		const expmax = 3 * time.Millisecond


### PR DESCRIPTION
⚠️ **NO MERGE**: demonstration purposes only.

## Description

Demonstrate how to use [benchttp/action](https://github.com/benchttp/action) into a CI.
This example shows a failed run.

> Oops, I introduced a regression!

### How the action was used

```yml
name: run benchttp in CI
uses: benchttp/action@v1
with:
  version: v0.1.0
  options: -configFile=./my-benchttp-config.yml
```

### See the results
<img width="1006" alt="action-run-fail" src="https://user-images.githubusercontent.com/59995859/195060400-39c2f82c-a193-4015-a7ed-251c315f2e1c.png">
